### PR TITLE
Fixed problem with immutablejs collections

### DIFF
--- a/react-kurtsore.js
+++ b/react-kurtsore.js
@@ -1,5 +1,7 @@
 var _ = require("lodash"),
-    k = require("kurtsore");
+    k = require("kurtsore"),
+    Immutable = require("immutable");
+;
 
 // ================================================================================
 // Mixins
@@ -21,7 +23,7 @@ var CursorPropsMixin = {
         }
 
         // Have the mutable props changed?
-        if (isDifferent(mutableCurrentProps, mutableNextProps)){
+        if (isDifferent(mutableCurrentProps, mutableNextProps, equalsCustomizer)){
             return true;
         }
 
@@ -74,6 +76,16 @@ function cursorShouldUpdate(cursors){
         newC = cursors[1];
     return !oldC.hasSameSnapshot(newC);
 };
+
+function equalsCustomizer(val1, val2) {
+    if (Immutable.Iterable.isIterable(val1) && Immutable.Iterable.isIterable(val2)) {
+        return Immutable.is(val1, val2);
+    } else if (Immutable.Iterable.isIterable(val1) || Immutable.Iterable.isIterable(val2)) {
+        return false;
+    } else {
+        return undefined;
+    }
+}
 
 // ================================================================================
 //  Public API


### PR DESCRIPTION
This PR solves a "deprecation" problem.

Normally we use the cursors with ImmutableJS data. When the data inside the cusor is an iterable lodash `_.isEqual` tries to see their equality by a deep equals of both objects.

This is not the better way for immutablejs collections.

The PR adds a "customizer" this is a function that I pass to the lodash `isEqual` that checks if the two objects being compared are from the ImmutableJS type and, if they are, tries to use the method from ImmutableJS.
